### PR TITLE
checkcfg: check access to plugin configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,6 @@ SUBDIR+=	command-mystats
 SUBDIR+=	stats
 SUBDIR+=	zfssnap
 SUBDIR+=	command-serve
+SUBDIR+=	checkcfg
 
 .include <bsd.subdir.mk>

--- a/checkcfg/Makefile
+++ b/checkcfg/Makefile
@@ -1,0 +1,26 @@
+.include <bsd.own.mk>
+
+PREFIX?=	/usr/local
+LIBDIR=		${PREFIX}/lib/pkg/
+SHLIB_DIR?=	${LIBDIR}/
+SHLIB_NAME?=	${PLUGIN_NAME}.so
+
+PLUGIN_NAME=	checkcfg
+SRCS=		checkcfg.c
+
+PKGFLAGS!=	pkgconf --cflags pkg
+CFLAGS+=	${PKGFLAGS}
+
+PKG=		pkg
+PKG_CFG=	pkg.conf
+
+beforeinstall:
+	${INSTALL} -d ${LIBDIR}
+
+run: ${SHLIB_NAME}
+	${PKG} -C ${PKG_CFG} plugins
+
+test: ${SHLIB_NAME}
+	${PKG} -C ${PKG_CFG} plugins | egrep -q "^checkcfg[[:space:]]+Configuration available: YES[[:space:]]"
+
+.include <bsd.lib.mk>

--- a/checkcfg/Makefile
+++ b/checkcfg/Makefile
@@ -21,6 +21,6 @@ run: ${SHLIB_NAME}
 	${PKG} -C ${PKG_CFG} plugins
 
 test: ${SHLIB_NAME}
-	${PKG} -C ${PKG_CFG} plugins | egrep -q "^checkcfg[[:space:]]+Configuration available: YES[[:space:]]"
+	${PKG} -C ${PKG_CFG} plugins | egrep "^checkcfg[[:space:]]+Configuration available: YES[[:space:]]"
 
 .include <bsd.lib.mk>

--- a/checkcfg/README.md
+++ b/checkcfg/README.md
@@ -1,0 +1,42 @@
+## General Information
+
+The *checkcfg* plugin checks if plugins have access to their configuration data.
+
+## How to build the plugin?
+
+In order to build the plugin enter into the plugin's directory and run make(1), e.g.:
+
+	$ cd /path/to/checkcfg
+	$ make
+	
+## How to check if plugins have acces to their configuration data
+
+If the plugin is displayed when pkg(8) is invoked with the `plugins` command, the
+status line for the plugin will indicate if plugins can access their configuration data.
+From within the plugin's build directory, run:
+
+	$ pkg -C pkg.conf plugins
+	NAME       DESC                                          VERSION   
+	checkcfg   Configuration available: YES                  1.0.0     
+
+For convenience, the same result can be achieved by invoking the `run` target via make(1), e.g.:
+
+	$ make run
+	NAME       DESC                                          VERSION   
+	checkcfg   Configuration available: YES                  1.0.0     
+
+If the description field of *checkcfg* says `YES`, access is possible. If it says `NO`,
+plugins cannot access their configuration data.
+
+The easiest way to check is by invoking the `test` target via make(1), e.g.:
+
+	$ make test
+
+If make(1) returns without errors, the current pkg(8) tool allows plugins to access
+their configuration data.
+
+To test a specific pkg(8) binary, set `PKG` when invoking the `run` and `test` targets:
+
+	$ make PKG=/path/to/pkg run
+	$ make PKG=/path/to/pkg test
+

--- a/checkcfg/checkcfg.c
+++ b/checkcfg/checkcfg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
+ * Copyright (c) 2020 Markus Stoff
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/checkcfg/checkcfg.c
+++ b/checkcfg/checkcfg.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Include other headers if needed */
+#include <stdio.h>
+
+/* Include pkg */
+#include <pkg.h>
+
+/* Define plugin name and configuration settings */
+static const char PLUGIN_NAME[] = "checkcfg";
+static const char PLUGIN_VERSION[] = "1.0.0";
+
+/*
+ * Upon successful initialization of the plugin EPKG_OK (0) is returned and
+ * upon failure EPKG_FATAL ( > 0 ) is returned to the caller.
+ */
+int
+pkg_plugin_init(struct pkg_plugin *p)
+{
+	const pkg_object *cfg = NULL;
+	bool hasConfig = false;
+	char message[80];
+
+	/* Get configuration object */
+	cfg = pkg_plugin_conf(p);
+
+	/* Confirm access to configuration options */
+	hasConfig = (pkg_object_type(cfg) == PKG_OBJECT);
+	snprintf(message, sizeof(message), "Configuration available: %s", hasConfig ? "YES" : "NO");
+
+	/* Register plugin */
+	pkg_plugin_set(p, PKG_PLUGIN_NAME, PLUGIN_NAME);
+	pkg_plugin_set(p, PKG_PLUGIN_VERSION, PLUGIN_VERSION);
+	pkg_plugin_set(p, PKG_PLUGIN_DESC, message);
+
+	return (EPKG_OK);
+}
+

--- a/checkcfg/pkg.conf
+++ b/checkcfg/pkg.conf
@@ -1,0 +1,4 @@
+PKG_ENABLE_PLUGINS = true
+PKG_PLUGINS_DIR    = .
+PLUGINS_CONF_DIR   = /dev/null
+PLUGINS            = [ "checkcfg" ]


### PR DESCRIPTION
The **checkcfg** plugin checks if pkg(8) allows plugins to access their configuration data.

It basically tests for the implementation of https://github.com/freebsd/pkg/pull/1844 .